### PR TITLE
feat: add toggle functionality for favorites and archive buttons

### DIFF
--- a/src/components/Task/TaskCard.tsx
+++ b/src/components/Task/TaskCard.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 import styles from './TaskCard.module.css';
 import { TaskCardProps } from '../../types/task-card-props';
+import { useAppDispatch } from '../../store/hooks';
+import { toggleArchiveTask, toggleFavoriteTask } from '../../store/thunks/task-thunks';
 
 const Task: React.FC<TaskCardProps> = ({ task }) => {
+  const dispatch = useAppDispatch();
+
+  const handleFavoriteToggle = () => {
+    dispatch(toggleFavoriteTask(task.id));
+  };
+
+  const handleArchiveToggle = () => {
+    dispatch(toggleArchiveTask(task.id));
+  };
+
   const dueDate = new Date(task.due_date);
   const currentDate = new Date();
   const isOverdue = dueDate < currentDate;
@@ -26,11 +38,19 @@ const Task: React.FC<TaskCardProps> = ({ task }) => {
             <button type="button" className={`${styles.cardBtn} ${styles.cardBtnEdit}`}>
               edit
             </button>
-            <button type="button" className={`${styles.cardBtn} ${styles.cardBtnArchive}`}>
-              archive
+            <button
+              type="button"
+              className={`${styles.cardBtn} ${styles.cardBtnArchive} ${task.is_favorite ? styles.cardBtnDisabled : ''}`}
+              onClick={handleFavoriteToggle}
+            >
+              {task.is_favorite ? 'Unfavorite' : 'Favorite'}
             </button>
-            <button type="button" className={styles.cardBtn}>
-              favorites
+            <button
+              type="button"
+              className={`${styles.cardBtn} ${task.is_archived ? styles.cardBtnDisabled : ''}`}
+              onClick={handleArchiveToggle}
+            >
+              {task.is_archived ? 'Unarchive' : 'Archive'}
             </button>
           </div>
 

--- a/src/store/slices/taskSlice.ts
+++ b/src/store/slices/taskSlice.ts
@@ -1,6 +1,13 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { initialTaskState } from '../../types/task-state';
-import { addTask, editTask, fetchTasks, removeTask } from '../thunks/task-thunks';
+import {
+  addTask,
+  editTask,
+  fetchTasks,
+  removeTask,
+  toggleArchiveTask,
+  toggleFavoriteTask,
+} from '../thunks/task-thunks';
 import {
   handlePending,
   handleRejected,
@@ -8,7 +15,9 @@ import {
   handleAddFulfilled,
   handleEditFulfilled,
   handleRemoveFulfilled,
-} from '../stateHandlers/taskHandlers'; // Импортируем вспомогательные функции
+  handleToggleFavoriteFulfilled,
+  handleToggleArchiveFulfilled,
+} from '../stateHandlers/taskHandlers';
 
 const taskSlice = createSlice({
   name: 'tasks',
@@ -34,7 +43,15 @@ const taskSlice = createSlice({
       // Remove task
       .addCase(removeTask.pending, handlePending)
       .addCase(removeTask.fulfilled, handleRemoveFulfilled)
-      .addCase(removeTask.rejected, handleRejected);
+      .addCase(removeTask.rejected, handleRejected)
+
+      // Toggle favorite
+      .addCase(toggleFavoriteTask.fulfilled, handleToggleFavoriteFulfilled)
+      .addCase(toggleFavoriteTask.rejected, handleRejected)
+
+      // Toggle archive
+      .addCase(toggleArchiveTask.fulfilled, handleToggleArchiveFulfilled)
+      .addCase(toggleArchiveTask.rejected, handleRejected);
   },
 });
 

--- a/src/store/stateHandlers/taskHandlers.ts
+++ b/src/store/stateHandlers/taskHandlers.ts
@@ -46,3 +46,21 @@ export const handleRemoveFulfilled = (
   state.loading = false;
   state.tasks = state.tasks.filter((task) => task.id !== action.payload);
 };
+
+export const handleToggleFavoriteFulfilled = (
+  state: typeof initialTaskState,
+  action: PayloadAction<TaskType>,
+) => {
+  state.tasks = state.tasks.map((task) =>
+    task.id === action.payload.id ? { ...task, is_favorite: action.payload.is_favorite } : task,
+  );
+};
+
+export const handleToggleArchiveFulfilled = (
+  state: typeof initialTaskState,
+  action: PayloadAction<TaskType>,
+) => {
+  state.tasks = state.tasks.map((task) =>
+    task.id === action.payload.id ? { ...task, is_archived: action.payload.is_archived } : task,
+  );
+};

--- a/src/store/thunks/task-thunks.ts
+++ b/src/store/thunks/task-thunks.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { TaskType } from '../../types/task-types';
 import { getTasks, createTask, updateTask, deleteTask } from '../../api/api';
+import { RootState } from '../store';
 
 export const fetchTasks = createAsyncThunk<TaskType[], void, { rejectValue: string }>(
   'tasks/fetchTasks',
@@ -47,6 +48,42 @@ export const removeTask = createAsyncThunk<string, string, { rejectValue: string
       return id;
     } catch (error) {
       return thunkAPI.rejectWithValue('Failed to delete task');
+    }
+  },
+);
+
+export const toggleFavoriteTask = createAsyncThunk<TaskType, string, { rejectValue: string }>(
+  'tasks/toggleFavorite',
+  async (taskId, thunkAPI) => {
+    try {
+      const state = thunkAPI.getState() as RootState;
+      const task = state.tasks.tasks.find((task) => task.id === taskId);
+      if (!task) throw new Error('Task not found');
+
+      const updatedTask = { ...task, is_favorite: !task.is_favorite };
+
+      const response = await updateTask(taskId, updatedTask);
+      return response;
+    } catch (error) {
+      return thunkAPI.rejectWithValue('Failed to toggle favorite status');
+    }
+  },
+);
+
+export const toggleArchiveTask = createAsyncThunk<TaskType, string, { rejectValue: string }>(
+  'tasks/toggleArchive',
+  async (taskId, thunkAPI) => {
+    try {
+      const state = thunkAPI.getState() as RootState;
+      const task = state.tasks.tasks.find((task) => task.id === taskId);
+      if (!task) throw new Error('Task not found');
+
+      const updatedTask = { ...task, is_archived: !task.is_archived };
+
+      const response = await updateTask(taskId, updatedTask);
+      return response;
+    } catch (error) {
+      return thunkAPI.rejectWithValue('Failed to toggle archive status');
     }
   },
 );


### PR DESCRIPTION
- Implemented toggleFavoriteTask and toggleArchiveTask in task-thunks.

- Updated taskSlice with new cases for handling fulfilled and rejected states of toggleFavoriteTask.

- Ensured state updates trigger filter recalculations and ui changes accordingly.